### PR TITLE
Updates Publish Newsletter and Template

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,6 @@ repos:
       - id: pip-compile
         name: Compile Python requirements
 
-
       - id: pip-compile
         name: Upgrade Python dependencies
         stages: [manual]

--- a/publish_newsletter.py
+++ b/publish_newsletter.py
@@ -9,7 +9,7 @@ from src import newsletter
 from src.engine import engine
 
 
-def build_newsletter(issue: Issue) -> dict[str, str]:
+def build_newsletter(issue: Issue, buttondown_api: str) -> dict[str, str]:
     """Build the newsletter from a GitHub Issue"""
     template = engine.get_template("newsletter.md")
     content = template.render(issue=issue)
@@ -20,7 +20,7 @@ def build_newsletter(issue: Issue) -> dict[str, str]:
         publish_date=issue.newsletter_publish,
     )
 
-    return newsletter.build_email_from_content(shownotes)
+    return newsletter.build_email_from_content(shownotes, buttondown_api)
 
 
 def main(
@@ -60,8 +60,8 @@ def main(
 ) -> HTTPResponse:
     """Build the archive and schedule the newsletter"""
     repo = Repo(github_account, github_repo)
-    issue = Issue.from_issue_number(repo=repo, issue_id=issue)
-    return build_newsletter(issue)
+    issue = Issue.from_issue_number(repo=repo, issue_number=issue_number)
+    return build_newsletter(issue, buttondown_api)
 
 
 if __name__ == "__main__":

--- a/templates/newsletter.md
+++ b/templates/newsletter.md
@@ -15,7 +15,7 @@
 
 
 ### Watch the VOD on Youtube:
-https://youtube.com/watch/{{youtube}}
+https://youtube.com/watch/{{issue.youtube}}
 
 ### Take the content on the road with you!
-https://transistor.fm/s/{{podcast}}
+https://share.transistor.fm/s/{{issue.podcast}}


### PR DESCRIPTION
When reformatting some of the variables were not ported over. This gets `publish_newsletter.py` and the `templates/newsletter.md` back to the working format.