### PR TITLE
Buttondown and typer fixes

### DIFF
--- a/publish_newsletter.py
+++ b/publish_newsletter.py
@@ -8,6 +8,9 @@ from gh_issues import Issue, Repo
 from src import newsletter
 from src.engine import engine
 
+# disable pretty exceptions showing locals due to keys
+app = typer.Typer(pretty_exceptions_show_locals=False)
+
 
 def build_newsletter(issue: Issue, buttondown_api: str) -> dict[str, str]:
     """Build the newsletter from a GitHub Issue"""
@@ -23,6 +26,7 @@ def build_newsletter(issue: Issue, buttondown_api: str) -> dict[str, str]:
     return newsletter.build_email_from_content(shownotes, buttondown_api)
 
 
+@app.command()
 def main(
     issue_number: int = typer.Argument(
         ..., rich_help_panel="GitHub Information", help="Issue number to publish"
@@ -44,7 +48,7 @@ def main(
         help="The GitHub repo to use",
     ),
     github_api: str = typer.Option(
-        None,
+        "...",
         "--github-api",
         envvar="GITHUB_API_TOKEN",
         rich_help_panel="GitHub Information",
@@ -60,9 +64,9 @@ def main(
 ) -> HTTPResponse:
     """Build the archive and schedule the newsletter"""
     repo = Repo(github_account, github_repo)
-    issue = Issue.from_issue_number(repo=repo, issue_number=issue_number)
+    issue = Issue.from_issue_number(repo, issue_number, github_api)
     return build_newsletter(issue, buttondown_api)
 
 
 if __name__ == "__main__":
-    typer.run(main)
+    app()

--- a/src/newsletter.py
+++ b/src/newsletter.py
@@ -2,7 +2,7 @@ from collections import namedtuple
 
 import httpx
 
-schedule_email_url: str = "https://api.buttondown.email/v1/scheduled-emails"
+schedule_email_url: str = "https://api.buttondown.email/v1/emails"
 Shownotes = namedtuple("Shownotes", "subject content publish_date")
 
 

--- a/templates/newsletter.md
+++ b/templates/newsletter.md
@@ -8,13 +8,14 @@
 {% endfor %}
 
 You can share your thoughts on this topic by watching this week's Python Community News Extra!
+
 https://youtube.com/watch/{{issue.youtube}}
 
 ### Around the Community
 
 Get news from the community by subscribing to our [YouTube Channel](youtube.com/@pycommunitynews).
 
-{% for topic in shorts %}
+{% for topic in issue.get_content_issues('shorts') %}
 ### {{topic.title}}
 
 <small>Submitted by: [{{topic._user.login}}]({{topic._user.url}}) on {{topic._created_at|datetime_format}}</small>


### PR DESCRIPTION
[Changes]
- Disables showing locals in errors
- passes in GITHUB_API_TOKEN as required option
- removes kwarg passing in Issue.from_issue_number (was causing error based on GH-Issues bug)
- Buttondown URL scheme changed from `scheduled-emails` to `emails`